### PR TITLE
Fix vigencia controls when importing asegurados

### DIFF
--- a/src/main/java/api_microservice_aesa_emision_vida/repository/AseguradoControlCaRepository.java
+++ b/src/main/java/api_microservice_aesa_emision_vida/repository/AseguradoControlCaRepository.java
@@ -35,6 +35,8 @@ public interface AseguradoControlCaRepository extends JpaRepository<AseguradoCon
 
         boolean existsByMesVigencia(int mesVigencia);
 
+        boolean existsByMesVigenciaAndAnioVigencia(int mesVigencia, int anioVigencia);
+
         boolean existsByCiAndMesVigencia(int ci, int mesVigencia);
 
 


### PR DESCRIPTION
## Summary
- reset the in-memory state before processing a new Excel import and capture the mes/año vigencia
- add a repository query that checks the existence of a carga by mes y año to prevent duplicates
- fail fast when the file mixes vigencias distintas and reuse the detected vigencia for subsequent registros

## Testing
- mvn -q -DskipTests package *(fails: 403 Forbidden downloading parent pom)*

------
https://chatgpt.com/codex/tasks/task_e_68e421c2843883229466804c672395c6